### PR TITLE
Unified Bibliography

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -84,7 +84,7 @@ def find_versions(input: str) -> Dict[str, List[str]]:
 
 def find_bibliography(input: str) -> Dict[str, str]:
     bib_references_found = set(re.findall(r"\[[0-9]*?\]", input))
-    if len(bib_references_found) == 0:
+    if len(bib_references_found) < 5:
         bib_references_found = set(re.findall(r"\[.*?\]", input))
 
     res = {}

--- a/src/main.py
+++ b/src/main.py
@@ -56,7 +56,7 @@ def find_des(input: str) -> List[str]:
 
 
 def find_rsa(input: str) -> List[str]:
-    found = re.findall(r"RSA[-_ ]?(?:4096|2048|1024)", input)
+    found = re.findall(r"RSA[-_ ]?(?:4096|2048|1024)(?:[-/_](?:4096|2048|1024))?", input)
 
     return list(set(found))
 

--- a/src/main.py
+++ b/src/main.py
@@ -41,7 +41,8 @@ def find_eal(input: str) -> List[str]:
 
 def find_sha(input: str) -> List[str]:
     input = input.replace(" ", "")
-    found = re.findall(r"SHA[- ]?[0-9]+", input)
+    found = re.findall(r"SHA[-_ ]?(512|384|256|224|3|2|1)"
+                       r"([-/_ ]?(512|384|256|224|3|2|1))?", input)
 
     return list(set(found))
 

--- a/src/main.py
+++ b/src/main.py
@@ -42,7 +42,6 @@ def find_eal(input: str) -> List[str]:
 def find_sha(input: str) -> List[str]:
     input = input.replace(" ", "")
     found = re.findall(r"SHA[-_ ]?(?:512|384|256|224|3|2|1)(?:[-/_ ](?:512|384|256|224|3|2|1))?", input)
-    # found = re.findall(r"SHA[-_ ]?[0-9]+", input)
 
     return list(set(found))
 

--- a/src/main.py
+++ b/src/main.py
@@ -41,8 +41,8 @@ def find_eal(input: str) -> List[str]:
 
 def find_sha(input: str) -> List[str]:
     input = input.replace(" ", "")
-    found = re.findall(r"SHA[-_ ]?(512|384|256|224|3|2|1)"
-                       r"([-/_ ]?(512|384|256|224|3|2|1))?", input)
+    found = re.findall(r"SHA[-_ ]?(?:512|384|256|224|3|2|1)", input)
+    # found = re.findall(r"SHA[-_ ]?[0-9]+", input)
 
     return list(set(found))
 
@@ -56,7 +56,7 @@ def find_des(input: str) -> List[str]:
 
 
 def find_rsa(input: str) -> List[str]:
-    found = re.findall(r"RSA[- ]?[0-9]+", input)
+    found = re.findall(r"RSA[-_ ]?(?:4096|2048|1024)", input)
 
     return list(set(found))
 

--- a/src/main.py
+++ b/src/main.py
@@ -41,7 +41,7 @@ def find_eal(input: str) -> List[str]:
 
 def find_sha(input: str) -> List[str]:
     input = input.replace(" ", "")
-    found = re.findall(r"SHA[-_ ]?(?:512|384|256|224|3|2|1)", input)
+    found = re.findall(r"SHA[-_ ]?(?:512|384|256|224|3|2|1)(?:[-/_ ](?:512|384|256|224|3|2|1))?", input)
     # found = re.findall(r"SHA[-_ ]?[0-9]+", input)
 
     return list(set(found))

--- a/src/main.py
+++ b/src/main.py
@@ -83,7 +83,9 @@ def find_versions(input: str) -> Dict[str, List[str]]:
 
 
 def find_bibliography(input: str) -> Dict[str, str]:
-    bib_references_found = set(re.findall(r"\[.*?\]", input))
+    bib_references_found = set(re.findall(r"\[[0-9]*?\]", input))
+    if len(bib_references_found) == 0:
+        bib_references_found = set(re.findall(r"\[.*?\]", input))
 
     res = {}
     for i in bib_references_found:

--- a/src/main.py
+++ b/src/main.py
@@ -83,7 +83,7 @@ def find_versions(input: str) -> Dict[str, List[str]]:
 
 
 def find_bibliography(input: str) -> Dict[str, str]:
-    bib_references_found = set(re.findall(r"\[[0-9]*?\]", input))
+    bib_references_found = set(re.findall(r"\[[0-9]*-?[0-9]*?\]", input))
     if len(bib_references_found) < 5:
         bib_references_found = set(re.findall(r"\[.*?\]", input))
 


### PR DESCRIPTION
Citation styles should not be combined, so when there is [1], [2] etc, there should not be [JIL-AAPS], [PP00100], etc...

The aim is to prevent output like this:

```
    "bibliography": {
        "[5]": "Security IC Platform Protection Profile with Augmentation Packages, Registered and Certified by Bundesamt für Sicherheit in der Informationstechnik (BSI) under the reference BSI-CC-PP-0084-201",
        "[MODULAR-                        SFP and modular design information flow control SFP]": "to DESIGN] restrict the ability to",
        "[assignment: Module Presence of O.CODE_MODULE]": "to",
        "[14]": "Oracle. Java Card 3 Platform, Application Programming Interface, Classic Edition, Version 3.0.5.",
        "[SCP]": "Audit Data Storage (SCP) ...80 (SC) ..................................................................70 7.2.10.2 FIA_AFL.1",
        "[2]": "Common Criteria for Information Technology Security Evaluation, Part 2: Security functional components, Version 3.1, Revision 5, CCMB-2017-04-002, April 2017.",
        "[CFG]": "Timing of identification 7.4.4 Applet Management .........................................85 (CFG) ............................................................... 73 7",
        "[DAP]": "",
        "[INSTALLER]": "by inherent memory cleanup in case of aborted loading and installation. 8.2.4 SF.CRYPTO: Cryptographic Functionality SF.CRYPTO provides key creation, key management, key deletion and cry",
        "[RSASignaturePKCS1]": "cryptographic operations] verification",
        "[assignment: list of subjects]": "with the capability to store",
...
```

where along the correct citations, there is a couple of irrelevant things just because they are in the square brackets too.

The downside is that if an author mixes the citation styles, the parser will not catch all the citations. However, it reduces false positives produced by the usage of square brackets (at least when the author uses the IEEE referencing style).